### PR TITLE
Add proper user ID support

### DIFF
--- a/src/main/groovy/grails/plugin/springsecurity/cas/userdetails/CasDomainUserMapperService.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/cas/userdetails/CasDomainUserMapperService.groovy
@@ -40,8 +40,18 @@ class CasDomainUserMapperService implements DomainUserMapper{
 	}
 
 	def createUser(String username, AttributePrincipal principal, Collection<GrantedAuthority> authorities){
+		def id
+		if (principal.attributes?.id) {
+			try {
+				id = Long.parseLong(principal.attributes.id)
+			} catch (NumberFormatException e) {
+				id = principal.attributes.id
+			}
+		} else {
+			id = username
+		}
 
-		new CasUser(username, NON_EXISTENT_PASSWORD_VALUE, true, true, true,
+		new CasUser(id, username, NON_EXISTENT_PASSWORD_VALUE, true, true, true,
 			true, authorities, principal.attributes)
 	}
 }

--- a/src/main/groovy/grails/plugin/springsecurity/cas/userdetails/CasUser.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/cas/userdetails/CasUser.groovy
@@ -21,7 +21,8 @@ class CasUser extends GrailsUser {
 
 	final HashMap attributes
 
-	CasUser(String username,
+	CasUser(def id,
+			String username,
 			String password,
 			boolean enabled,
 			boolean accountNonExpired,
@@ -30,7 +31,7 @@ class CasUser extends GrailsUser {
 			Collection<GrantedAuthority> authorities,
 			HashMap attributes) {
 		super(username, password, enabled, accountNonExpired,
-			credentialsNonExpired, accountNonLocked, authorities, username)
+			credentialsNonExpired, accountNonLocked, authorities, id)
 		this.attributes = attributes
 	}
 


### PR DESCRIPTION
Problem: the plugin uses username for user ID, it causes en error when ID is Long in the system (Long is more common type for such property I guess). 

All atrubutes from CAS are translated to string here Saml11TicketValidator. So we need to deal with it somehow to get proper user ID.